### PR TITLE
add support for audio per inputstream

### DIFF
--- a/src/main/java/com/github/catalystcode/fortis/speechtotext/Transcriber.java
+++ b/src/main/java/com/github/catalystcode/fortis/speechtotext/Transcriber.java
@@ -38,9 +38,9 @@ public abstract class Transcriber {
         return create(audioPath, config, new NvSpeechServiceClient());
     }
 	
-	public static Transcriber create(SpeechServiceConfig config) {
-		return create(config, new NvSpeechServiceClient());
-	}
+    public static Transcriber create(SpeechServiceConfig config) {
+        return create(config, new NvSpeechServiceClient());
+    }
 
     private static Transcriber create(String audioPath, SpeechServiceConfig config, SpeechServiceClient client) {
         if (audioPath.endsWith(".wav")) {
@@ -54,7 +54,7 @@ public abstract class Transcriber {
         throw new IllegalArgumentException("Unsupported audio file type: " + audioPath);
     }
 	
-	private static Transcriber create(SpeechServiceConfig config, SpeechServiceClient client) {
-		return new WavTranscriber(config, client);
-	}
+    private static Transcriber create(SpeechServiceConfig config, SpeechServiceClient client) {
+        return new WavTranscriber(config, client);
+    }
 }


### PR DESCRIPTION
Transcriber.create was added with no need for an audioPath, for situations where the file origin is not a path.
It always instantiates the WavTranscriber, because all audiostreams in my project are transcoded to wav.