### PR TITLE
Add event handlers for "turn.start" and "turn.end".

### DIFF
--- a/src/main/java/SpeechToTextWebsocketsDemo.java
+++ b/src/main/java/SpeechToTextWebsocketsDemo.java
@@ -24,13 +24,14 @@ public class SpeechToTextWebsocketsDemo {
         final SpeechType speechType = SpeechType.CONVERSATION;
         final OutputFormat outputFormat = OutputFormat.SIMPLE;
         final String audioPath = args[0];
-        final Locale locale = new Locale(args.length > 1 ? args[1] : "en-US");
+        final Locale locale = Locale.forLanguageTag(args.length > 1 ? args[1] : "en-US");
         final String audioType = args.length > 2 ? args[2] : audioPath;
 
         SpeechServiceConfig config = new SpeechServiceConfig(subscriptionKey, speechType, outputFormat, locale);
 
         try (InputStream audioStream = openStream(audioPath)) {
-            Transcriber.create(audioType, config).transcribe(audioStream, SpeechToTextWebsocketsDemo::onPhrase, SpeechToTextWebsocketsDemo::onHypothesis);
+            Transcriber.create(audioType, config).transcribe(audioStream, SpeechToTextWebsocketsDemo::onPhrase, SpeechToTextWebsocketsDemo::onHypothesis,
+                    SpeechToTextWebsocketsDemo::onTurnStart, SpeechToTextWebsocketsDemo::onTurnEnd);
         }
     }
 
@@ -42,11 +43,19 @@ public class SpeechToTextWebsocketsDemo {
         return new BufferedInputStream(inputStream);
     }
 
+    private static void onTurnEnd() {
+        System.out.println("TurnEnd:");
+    }
+
     private static void onPhrase(String phrase) {
         System.out.println("Phrase: " + phrase);
     }
 
     private static void onHypothesis(String hypothesis) {
         System.out.println("Hypothesis: " + hypothesis);
+    }
+
+    private static void onTurnStart(String serviceTag) {
+        System.out.println("TurnStart: " + serviceTag);
     }
 }

--- a/src/main/java/com/github/catalystcode/fortis/speechtotext/Transcriber.java
+++ b/src/main/java/com/github/catalystcode/fortis/speechtotext/Transcriber.java
@@ -20,7 +20,12 @@ public abstract class Transcriber {
     }
 
     public void transcribe(InputStream audioStream, Consumer<String> onResult, Consumer<String> onHypothesis) throws Exception {
-        MessageReceiver receiver = new MessageReceiver(onResult, onHypothesis, client.getEndLatch());
+        transcribe(audioStream, onResult, onHypothesis);
+    }
+
+    public void transcribe(InputStream audioStream, Consumer<String> onResult, Consumer<String> onHypothesis,
+            Consumer<String> onTurnStart, Runnable onTurnEnd) throws Exception {
+        MessageReceiver receiver = new MessageReceiver(onResult, onHypothesis, onTurnStart, onTurnEnd, client.getEndLatch());
         try {
             MessageSender sender = client.start(config, receiver);
             receiver.setSender(sender);
@@ -37,7 +42,7 @@ public abstract class Transcriber {
     public static Transcriber create(String audioPath, SpeechServiceConfig config) {
         return create(audioPath, config, new NvSpeechServiceClient());
     }
-	
+
     public static Transcriber create(SpeechServiceConfig config) {
         return create(config, new NvSpeechServiceClient());
     }
@@ -53,8 +58,9 @@ public abstract class Transcriber {
 
         throw new IllegalArgumentException("Unsupported audio file type: " + audioPath);
     }
-	
+
     private static Transcriber create(SpeechServiceConfig config, SpeechServiceClient client) {
         return new WavTranscriber(config, client);
     }
+
 }

--- a/src/main/java/com/github/catalystcode/fortis/speechtotext/constants/SpeechServiceMessageFields.java
+++ b/src/main/java/com/github/catalystcode/fortis/speechtotext/constants/SpeechServiceMessageFields.java
@@ -9,4 +9,6 @@ public final class SpeechServiceMessageFields {
     public static final String END_OF_DICTATION_SILENCE_STATUS = "DictationEndSilenceTimeout";
     public static final String DISPLAY_TEXT = "DisplayText";
     public static final String HYPOTHESIS_TEXT = "Text";
+    public static final String CONTEXT = "context";
+    public static final String SERVICE_TAG = "serviceTag";
 }

--- a/src/main/java/com/github/catalystcode/fortis/speechtotext/lifecycle/TurnEndMessage.java
+++ b/src/main/java/com/github/catalystcode/fortis/speechtotext/lifecycle/TurnEndMessage.java
@@ -8,11 +8,13 @@ final class TurnEndMessage {
     private TurnEndMessage() {}
 
     static void handle(MessageSender sender, CountDownLatch turnEndLatch, Runnable onTurnEnd) {
-        if (onTurnEnd != null) {
-            onTurnEnd.run();
+        try {
+            if (onTurnEnd != null) {
+                onTurnEnd.run();
+            }
+        } finally {
+            sender.sendTelemetry();
+            turnEndLatch.countDown();
         }
-
-        sender.sendTelemetry();
-        turnEndLatch.countDown();
     }
 }

--- a/src/main/java/com/github/catalystcode/fortis/speechtotext/lifecycle/TurnEndMessage.java
+++ b/src/main/java/com/github/catalystcode/fortis/speechtotext/lifecycle/TurnEndMessage.java
@@ -7,7 +7,11 @@ import java.util.concurrent.CountDownLatch;
 final class TurnEndMessage {
     private TurnEndMessage() {}
 
-    static void handle(MessageSender sender, CountDownLatch turnEndLatch) {
+    static void handle(MessageSender sender, CountDownLatch turnEndLatch, Runnable onTurnEnd) {
+        if (onTurnEnd != null) {
+            onTurnEnd.run();
+        }
+
         sender.sendTelemetry();
         turnEndLatch.countDown();
     }

--- a/src/main/java/com/github/catalystcode/fortis/speechtotext/lifecycle/TurnStartMessage.java
+++ b/src/main/java/com/github/catalystcode/fortis/speechtotext/lifecycle/TurnStartMessage.java
@@ -1,0 +1,21 @@
+package com.github.catalystcode.fortis.speechtotext.lifecycle;
+
+import static com.github.catalystcode.fortis.speechtotext.constants.SpeechServiceMessageFields.*;
+
+import java.util.function.Consumer;
+
+import org.json.JSONObject;;
+
+final class TurnStartMessage {
+    private TurnStartMessage() {}
+
+    static void handle(JSONObject message, Consumer<String> onTurnStart) {
+        if (onTurnStart == null) {
+            return;
+        }
+
+        JSONObject context = message.getJSONObject(CONTEXT);
+        String serviceTag = context.getString(SERVICE_TAG);
+        onTurnStart.accept(serviceTag);
+    }
+}


### PR DESCRIPTION
Transcriber can now set event handlers for "turn.start" and "turn.end" messages.

I would like to cooperate with continuous delivery proposed in　https://github.com/CatalystCode/SpeechToText-WebSockets-Java/issues/3#issuecomment-381618093

However, because there is no knowledge of Travis, I do not know what to do specifically.

Can you get some hints?